### PR TITLE
Disable heavy scanning in chronicle

### DIFF
--- a/chronicle.lua
+++ b/chronicle.lua
@@ -1,4 +1,4 @@
--- Chronicles fortress events (deaths, artifacts, invasions)
+-- Chronicles fortress events (currently only unit deaths)
 --@module = true
 --@enable = true
 
@@ -64,10 +64,10 @@ local function check_invasions()
     end
 end
 
+-- main loop; artifact and invasion tracking disabled to avoid scanning large
+-- data structures, which was causing hangs on some forts
 local function event_loop()
     if not state.enabled then return end
-    check_artifacts()
-    check_invasions()
     dfhack.timeout(1200, 'ticks', event_loop)
 end
 

--- a/docs/chronicle.rst
+++ b/docs/chronicle.rst
@@ -2,12 +2,12 @@ chronicle
 =========
 
 .. dfhack-tool::
-    :summary: Record fortress events like deaths, artifacts, and invasions.
+    :summary: Record fortress events like deaths. Artifact and invasion tracking disabled.
     :tags: fort gameplay
 
 This tool automatically records notable events in a chronicle that is stored
-with your save. The chronicle contains entries for unit deaths, newly created
-artifacts, and the start of invasions.
+with your save. Currently only unit deaths are recorded since artifact and
+invasion tracking has been disabled due to performance issues.
 
 Usage
 -----


### PR DESCRIPTION
## Summary
- disable artifact/invasion checks to prevent game freezes
- document that only death events are recorded for now

## Testing
- `pre-commit run --files chronicle.lua docs/chronicle.rst`

------
https://chatgpt.com/codex/tasks/task_e_687be060bb54832ab1f8863306d06777