### PR TITLE
Add empty chronicle notice and item creation events

### DIFF
--- a/docs/chronicle.rst
+++ b/docs/chronicle.rst
@@ -2,11 +2,12 @@ chronicle
 =========
 
 .. dfhack-tool::
-    :summary: Record fortress events like deaths, artifacts, and invasions.
+    :summary: Record fortress events like deaths, item creation, and invasions.
     :tags: fort gameplay
 
 This tool automatically records notable events in a chronicle that is stored
-with your save. Unit deaths, artifact creation, and invasions are recorded.
+with your save. Unit deaths, all item creation events, and invasions are
+recorded.
 
 Usage
 -----
@@ -23,6 +24,6 @@ Usage
 ``chronicle disable``
     Stop recording events.
 ``chronicle print``
-    Print all recorded events.
+    Print all recorded events. Prints a notice if the chronicle is empty.
 ``chronicle clear``
     Delete the chronicle.


### PR DESCRIPTION
## Summary
- track creation of all items (not just artifacts) in `chronicle.lua`
- print a message when the chronicle has no entries
- note item creation and empty output behaviour in the docs

## Testing
- `pre-commit run --files chronicle.lua docs/chronicle.rst`

------
https://chatgpt.com/codex/tasks/task_e_687be6fe22a4832a99e06c3d5f8fc1ef