### PR TITLE
Fix holy-war mutual war

### DIFF
--- a/docs/holy-war.rst
+++ b/docs/holy-war.rst
@@ -9,7 +9,9 @@ This tool compares the spheres of influence represented by the gods of
 nearby civilizations with those worshipped by your civilization and
 represented in fortress temples. If no spheres overlap, or if the
 historical record shows a ``religious_persecution_grudge`` between the
-two peoples, the civilization is set to war.
+two peoples, the civilization is set to war. Both your stance toward
+the other civilization and their stance toward you are set to war,
+ensuring a mutual declaration.
 
 Usage
 -----

--- a/holy-war.lua
+++ b/holy-war.lua
@@ -128,14 +128,21 @@ local function main(...)
 
     for _, civ in ipairs(df.global.world.entities.all) do
         if civ.type == 0 and civ.id ~= pciv.id then
-            local status
+            local p_status
             for _, state in ipairs(pciv.relations.diplomacy.state) do
                 if state.group_id == civ.id then
-                    status = state.relation
+                    p_status = state.relation
                     break
                 end
             end
-            if status == 0 or status == nil then -- peace or unknown
+            local c_status
+            for _, state in ipairs(civ.relations.diplomacy.state) do
+                if state.group_id == pciv.id then
+                    c_status = state.relation
+                    break
+                end
+            end
+            if p_status ~= 1 or c_status ~= 1 then -- not already mutually at war
                 local civ_spheres = get_civ_spheres(civ)
                 local civ_hfs = get_civ_hists(civ)
                 if not share(player_spheres, civ_spheres) or


### PR DESCRIPTION
## Summary
- ensure `holy-war` checks both sides before declaring war so relations become mutual
- document that the script sets war for both civilizations

## Testing
- `pre-commit run --files holy-war.lua docs/holy-war.rst`

------
https://chatgpt.com/codex/tasks/task_e_687bef42346c832a958b641db7711ca0