### PR TITLE
Fix chronicle UTF-8 issues

### DIFF
--- a/docs/chronicle.rst
+++ b/docs/chronicle.rst
@@ -16,7 +16,7 @@ Usage
 
     chronicle enable
     chronicle disable
-    chronicle print
+    chronicle print [count]
     chronicle clear
 
 ``chronicle enable``
@@ -24,6 +24,8 @@ Usage
 ``chronicle disable``
     Stop recording events.
 ``chronicle print``
-    Print all recorded events. Prints a notice if the chronicle is empty.
+    Print the most recent recorded events. Takes an optional ``count``
+    argument (default ``25``) that specifies how many events to show. Prints
+    a notice if the chronicle is empty.
 ``chronicle clear``
     Delete the chronicle.


### PR DESCRIPTION
## Summary
- sanitize chronicle entries to avoid invalid UTF-8
- show dates at the start of entries using dwarf month names
- limit printed entries to a default of 25 (configurable)

## Testing
- `pre-commit run --files chronicle.lua docs/chronicle.rst`


------
https://chatgpt.com/codex/tasks/task_e_687bf11bf950832a9c93c67724bcda75