### PR TITLE
Summarize non-artifact item creation

### DIFF
--- a/docs/chronicle.rst
+++ b/docs/chronicle.rst
@@ -6,8 +6,8 @@ chronicle
     :tags: fort gameplay
 
 This tool automatically records notable events in a chronicle that is stored
-with your save. Unit deaths, all item creation events, and invasions are
-recorded.
+with your save. Unit deaths, artifact creation events, invasions, and yearly
+totals of crafted items are recorded.
 
 Usage
 -----
@@ -17,6 +17,7 @@ Usage
     chronicle enable
     chronicle disable
     chronicle print [count]
+    chronicle summary
     chronicle clear
 
 ``chronicle enable``
@@ -27,5 +28,7 @@ Usage
     Print the most recent recorded events. Takes an optional ``count``
     argument (default ``25``) that specifies how many events to show. Prints
     a notice if the chronicle is empty.
+``chronicle summary``
+    Show yearly totals of created items by category (non-artifact items only).
 ``chronicle clear``
     Delete the chronicle.


### PR DESCRIPTION
## Summary
- enhance chronicle to aggregate non-artifact items by year and category
- ignore corpse-related items when counting
- add `chronicle summary` command
- document item summary command

## Testing
- `luacheck` not available, no tests run

------
https://chatgpt.com/codex/tasks/task_e_687bf58ec660832a955bb89b1d65a7bb