### PR TITLE
Improve chronicle artifact logging

### DIFF
--- a/docs/chronicle.rst
+++ b/docs/chronicle.rst
@@ -7,7 +7,9 @@ chronicle
 
 This tool automatically records notable events in a chronicle that is stored
 with your save. Unit deaths, artifact creation events, invasions, and yearly
-totals of crafted items are recorded.
+totals of crafted items are recorded. Artifact entries now include the full
+announcement text from the game, complete with item descriptions and special
+characters rendered just as they appear in the in-game logs.
 
 Usage
 -----


### PR DESCRIPTION
## Summary
- show game-encoded text so artifact names render correctly
- record full artifact creation announcements from game reports
- document that artifact entries now include the in‑game announcement

## Testing
- `luacheck chronicle.lua`

------
https://chatgpt.com/codex/tasks/task_e_687bfae16e14832a99fcf5982f121d2c