### PR TITLE
Fix chronicle UTF-8 handling

### DIFF
--- a/chronicle.lua
+++ b/chronicle.lua
@@ -59,8 +59,8 @@ local function format_date(year, ticks)
 end
 
 local function sanitize(text)
-    -- convert game strings to console encoding and remove non-printable characters
-    local str = dfhack.df2console(text or '')
+    -- convert game strings to UTF-8 and remove non-printable characters
+    local str = dfhack.df2utf(text or '')
     -- strip control characters that may have leaked through
     str = str:gsub('[%z\1-\31]', '')
     return str
@@ -151,7 +151,7 @@ local pending_artifact_report
 local function on_report(report_id)
     local rep = df.report.find(report_id)
     if not rep or not rep.flags.announcement then return end
-    local text = dfhack.df2console(rep.text)
+    local text = dfhack.df2utf(rep.text)
     if pending_artifact_report then
         if text:find(' offers it to ') then
             local date = format_date(df.global.cur_year, df.global.cur_year_tick)


### PR DESCRIPTION
## Summary
- convert chronicle text entries to UTF-8 before storing
- read artifact reports as UTF-8 strings

## Testing
- `pre-commit run --files chronicle.lua`

------
https://chatgpt.com/codex/tasks/task_e_687bff05a6cc832abeebf2ba6d4812c7