### PR TITLE
Improve chronicle notifications

### DIFF
--- a/docs/chronicle.rst
+++ b/docs/chronicle.rst
@@ -6,10 +6,13 @@ chronicle
     :tags: fort gameplay
 
 This tool automatically records notable events in a chronicle that is stored
-with your save. Unit deaths, artifact creation events, invasions, and yearly
-totals of crafted items are recorded. Artifact entries now include the full
-announcement text from the game, complete with item descriptions and special
-characters rendered just as they appear in the in-game logs.
+with your save. Unit deaths now include the cause of death as well as any
+titles, nicknames, or noble positions held by the fallen. Artifact creation
+events, invasions, mission reports, and yearly totals of crafted items are also
+recorded. Announcements for masterwork creations can be toggled on or off
+and are enabled by default. Artifact entries include the full announcement text
+from the game, and output text is sanitized so that any special characters are
+replaced with simple Latin equivalents.
 
 Usage
 -----
@@ -21,6 +24,8 @@ Usage
     chronicle print [count]
     chronicle summary
     chronicle clear
+    chronicle masterworks <enable|disable>
+    chronicle export [filename]
 
 ``chronicle enable``
     Start recording events in the current fortress.
@@ -34,3 +39,9 @@ Usage
     Show yearly totals of created items by category (non-artifact items only).
 ``chronicle clear``
     Delete the chronicle.
+``chronicle masterworks``
+    Enable or disable logging of masterwork creation announcements. When run
+    with no argument, displays the current setting.
+``chronicle export``
+    Write all recorded events to a text file. If ``filename`` is omitted, the
+    output is saved as ``chronicle.txt`` in your save folder.


### PR DESCRIPTION
## Summary
- transliterate unicode punctuation and accents when writing chronicle entries
- record siege parley, named weapon, mission report, and found-dead announcements
- add detailed death event descriptions with titles and positions
- make masterwork announcements configurable
- add export command to dump the chronicle to a text file
- document new masterwork toggle and export

## Testing
- `luac -p chronicle.lua`


------
https://chatgpt.com/codex/tasks/task_e_687c06aea00c832aba679e4a2347ad1a