### PR TITLE
Handle DF quality wrappers

### DIFF
--- a/chronicle.lua
+++ b/chronicle.lua
@@ -94,6 +94,14 @@ local function sanitize(text)
     -- strip control characters that may have leaked through
     str = str:gsub('[%z\1-\31]', '')
     str = transliterate(str)
+    -- strip quality wrappers from item names
+    -- e.g. -item-, +item+, *item*, ≡item≡, ☼item☼, «item»
+    str = str:gsub('%-([^%-]+)%-', '%1')
+    str = str:gsub('%+([^%+]+)%+', '%1')
+    str = str:gsub('%*([^%*]+)%*', '%1')
+    str = str:gsub('≡([^≡]+)≡', '%1')
+    str = str:gsub('☼([^☼]+)☼', '%1')
+    str = str:gsub('«([^»]+)»', '%1')
     return str
 end
 


### PR DESCRIPTION
## Summary
- sanitize chronicle events to remove quality wrapper characters around item names

## Testing
- `pre-commit run --files chronicle.lua`

------
https://chatgpt.com/codex/tasks/task_e_687c0f1f7bfc832ab1911be7ecb10539