### PR TITLE
Handle DF quality wrappers

### DIFF
--- a/chronicle.lua
+++ b/chronicle.lua
@@ -94,6 +94,19 @@ local function sanitize(text)
     -- strip control characters that may have leaked through
     str = str:gsub('[%z\1-\31]', '')
     str = transliterate(str)
+    -- strip quality wrappers from item names
+    -- e.g. -item-, +item+, *item*, ≡item≡, ☼item☼, «item»
+    str = str:gsub('%-([^%-]+)%-', '%1')
+    str = str:gsub('%+([^%+]+)%+', '%1')
+    str = str:gsub('%*([^%*]+)%*', '%1')
+    str = str:gsub('≡([^≡]+)≡', '%1')
+    str = str:gsub('☼([^☼]+)☼', '%1')
+    str = str:gsub('«([^»]+)»', '%1')
+    -- remove any stray wrapper characters that might remain
+    str = str:gsub('[☼≡«»]', '')
+    -- strip any remaining characters outside of latin letters, digits, and
+    -- basic punctuation
+    str = str:gsub("[^A-Za-z0-9%s%.:,;!'\"%?()%+%-]", '')
     return str
 end
 


### PR DESCRIPTION
## Summary
- sanitize chronicle events to remove quality wrapper characters around item names
- filter any characters that aren't latin letters, digits, or standard punctuation

## Testing
- `pre-commit run --files chronicle.lua`


------
https://chatgpt.com/codex/tasks/task_e_687c0f1f7bfc832ab1911be7ecb10539