### PR TITLE
Add chronicle viewer GUI

### DIFF
--- a/chronicle.lua
+++ b/chronicle.lua
@@ -419,6 +419,12 @@ local function main(args)
                 print(state.entries[i])
             end
         end
+    elseif cmd == 'view' then
+        if #state.entries == 0 then
+            print('Chronicle is empty.')
+        else
+            reqscript('gui/chronicle').show()
+        end
     elseif cmd == 'summary' then
         local years = {}
         for year in pairs(state.item_counts) do table.insert(years, year) end

--- a/docs/chronicle.rst
+++ b/docs/chronicle.rst
@@ -26,6 +26,7 @@ Usage
     chronicle clear
     chronicle masterworks <enable|disable>
     chronicle export [filename]
+    chronicle view
 
 ``chronicle enable``
     Start recording events in the current fortress.
@@ -45,6 +46,8 @@ Usage
 ``chronicle export``
     Write all recorded events to a text file. If ``filename`` is omitted, the
     output is saved as ``chronicle.txt`` in your save folder.
+``chronicle view``
+    Display the full chronicle in a scrollable window.
 
 Examples
 --------

--- a/gui/chronicle.lua
+++ b/gui/chronicle.lua
@@ -1,0 +1,66 @@
+-- GUI viewer for chronicle entries
+--@module=true
+
+local chronicle = reqscript('chronicle')
+local gui = require('gui')
+local widgets = require('gui.widgets')
+
+ChronicleView = defclass(ChronicleView, gui.FramedScreen)
+ChronicleView.ATTRS{
+    frame_title='Chronicle',
+    frame_style=gui.GREY_LINE_FRAME,
+    frame_width=60,
+    frame_height=20,
+    frame_inset=1,
+}
+
+function ChronicleView:init()
+    self.entries = chronicle.state and chronicle.state.entries or {}
+    self.start = 1
+    self.start_min = 1
+    self.start_max = math.max(1, #self.entries - self.frame_height + 1)
+end
+
+function ChronicleView:onRenderBody(dc)
+    for i=self.start, math.min(#self.entries, self.start + self.frame_height - 1) do
+        dc:string(self.entries[i]):newline()
+    end
+    dc:pen(COLOR_LIGHTCYAN)
+    if self.start > self.start_min then
+        dc:seek(self.frame_width-1,0):char(24)
+    end
+    if self.start < self.start_max then
+        dc:seek(self.frame_width-1,self.frame_height-1):char(25)
+    end
+end
+
+function ChronicleView:onInput(keys)
+    if keys.LEAVESCREEN or keys.SELECT then
+        self:dismiss()
+        view = nil
+    elseif keys.STANDARDSCROLL_UP then
+        self.start = math.max(self.start_min, self.start - 1)
+    elseif keys.STANDARDSCROLL_DOWN then
+        self.start = math.min(self.start_max, self.start + 1)
+    elseif keys.STANDARDSCROLL_PAGEUP then
+        self.start = math.max(self.start_min, self.start - self.frame_height)
+    elseif keys.STANDARDSCROLL_PAGEDOWN then
+        self.start = math.min(self.start_max, self.start + self.frame_height)
+    elseif keys.STANDARDSCROLL_TOP then
+        self.start = self.start_min
+    elseif keys.STANDARDSCROLL_BOTTOM then
+        self.start = self.start_max
+    else
+        ChronicleView.super.onInput(self, keys)
+    end
+end
+
+function show()
+    view = view and view:raise() or ChronicleView{}
+    view:show()
+end
+
+if not dfhack_flags.module then
+    show()
+end
+


### PR DESCRIPTION
## Summary
- add `gui/chronicle.lua` to display the chronicle in a scrollable window
- support new `chronicle view` command
- document the `view` command

## Testing
- `git commit -m "Add scrollable chronicle viewer"`

------
https://chatgpt.com/codex/tasks/task_e_687ce60508c8832a9b0fcdbc03bf9fc2