### PR TITLE
Fix chronicle log growth

### DIFF
--- a/docs/chronicle.rst
+++ b/docs/chronicle.rst
@@ -14,6 +14,10 @@ and are enabled by default. Artifact entries include the full announcement text
 from the game, and output text is sanitized so that any special characters are
 replaced with simple Latin equivalents.
 
+The chronicle file is trimmed to about 32KB of the most recent text so that it
+doesn't exceed DFHack's persistence limits. Trimmed entries are automatically
+appended to ``chronicle_full.txt`` in your save folder so nothing is lost.
+
 Usage
 -----
 
@@ -22,6 +26,7 @@ Usage
     chronicle enable
     chronicle disable
     chronicle print [count]
+    chronicle long
     chronicle summary
     chronicle clear
     chronicle masterworks <enable|disable>
@@ -46,6 +51,9 @@ Usage
 ``chronicle export``
     Write all recorded events to a text file. If ``filename`` is omitted, the
     output is saved as ``chronicle.txt`` in your save folder.
+``chronicle long``
+    Print the entire chronicle, including older entries stored in
+    ``chronicle_full.txt``.
 ``chronicle view``
     Display the full chronicle in a scrollable window.
 

--- a/gui/chronicle.lua
+++ b/gui/chronicle.lua
@@ -15,7 +15,7 @@ ChronicleView.ATTRS{
 }
 
 function ChronicleView:init()
-    self.entries = chronicle.state and chronicle.state.entries or {}
+    self.entries = chronicle.get_full_entries()
     self.start = 1
     self.start_min = 1
     self.start_max = math.max(1, #self.entries - self.frame_height + 1)
@@ -63,4 +63,3 @@ end
 if not dfhack_flags.module then
     show()
 end
-


### PR DESCRIPTION
## Summary
- preserve removed chronicle entries in *chronicle_full.txt*
- add `chronicle long` subcommand to print the full log
- show entire log when using the GUI viewer and exporting
- document how trimmed entries are saved automatically

## Testing
- `pre-commit run --files chronicle.lua docs/chronicle.rst gui/chronicle.lua`

------
https://chatgpt.com/codex/tasks/task_e_687ceadf6f84832ab0320dc3547f5792