### PR TITLE
Add debug option and configurable multihaul

### DIFF
--- a/docs/multihaul.rst
+++ b/docs/multihaul.rst
@@ -7,17 +7,31 @@ multihaul
 
 This tool allows dwarves to collect several adjacent items at once when
 performing hauling jobs with a bag or wheelbarrow. When enabled, new
-``StoreItemInStockpile`` jobs will automatically attach up to four additional
-items found within one tile of the original item so they can be hauled in a
-single trip.
+``StoreItemInStockpile`` jobs will automatically attach nearby items so they can
+be hauled in a single trip. By default, up to four additional items within one
+tile of the original item are collected.
 
 Usage
 -----
 
 ::
 
-    multihaul enable
+    multihaul enable [<options>]
     multihaul disable
     multihaul status
+    multihaul config [<options>]
 
 The script can also be enabled persistently with ``enable multihaul``.
+
+Options
+-------
+
+``--radius <tiles>``
+    Search this many tiles around the target item for additional items. Default
+    is ``1``.
+``--max-items <count>``
+    Attach at most this many additional items to each hauling job. Default is
+    ``4``.
+``--debug``
+    Show debug messages via ``dfhack.gui.showAnnouncement`` when items are
+    attached. Use ``--no-debug`` to disable.


### PR DESCRIPTION
## Summary
- enhance `multihaul` with config options and debugging
- document new parameters

## Testing
- `pre-commit run --files multihaul.lua docs/multihaul.rst`

------
https://chatgpt.com/codex/tasks/task_e_687cf76b4814832aa8afa865eab12624