### PR TITLE
Restrict multihaul to wheelbarrows

### DIFF
--- a/docs/multihaul.rst
+++ b/docs/multihaul.rst
@@ -2,11 +2,11 @@ multihaul
 =========
 
 .. dfhack-tool::
-    :summary: Haulers gather multiple nearby items when using bags or wheelbarrows.
+    :summary: Haulers gather multiple nearby items when using wheelbarrows.
     :tags: fort productivity items
 
 This tool allows dwarves to collect several adjacent items at once when
-performing hauling jobs with a bag or wheelbarrow. When enabled, new
+performing hauling jobs with a wheelbarrow. When enabled, new
 ``StoreItemInStockpile`` jobs will automatically attach nearby items so they can
 be hauled in a single trip. By default, up to four additional items within one
 tile of the original item are collected.

--- a/multihaul.lua
+++ b/multihaul.lua
@@ -1,4 +1,4 @@
--- Allow haulers to pick up multiple nearby items when using bags or wheelbarrows
+-- Allow haulers to pick up multiple nearby items when using wheelbarrows
 --@module = true
 --@enable = true
 
@@ -82,19 +82,18 @@ end
 local function on_new_job(job)
     if job.job_type ~= df.job_type.StoreItemInStockpile then return end
 
-    add_nearby_items(job)
-
-    local container
+    local wheelbarrow
     for _, jitem in ipairs(job.items) do
-        if jitem.item and (dfhack.items.getCapacity(jitem.item) > 0) then
-            container = jitem.item
+        if jitem.item and df.item_toolst:is_instance(jitem.item) and jitem.item:isWheelbarrow() then
+            wheelbarrow = jitem.item
             break
         end
     end
 
-    if container then
-        emptyContainedItems(container)
-    end
+    if not wheelbarrow then return end
+
+    add_nearby_items(job)
+    emptyContainedItems(wheelbarrow)
 end
 
 local function enable(state)


### PR DESCRIPTION
## Summary
- restrict multihaul script to run only for jobs using wheelbarrows
- update documentation to remove bag references

## Testing
- `apt-get update` *(fails: domain mise.jdx.dev blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687d8cefa4d4832aa08138d3663fa8d8