### PR TITLE
Improve wheelbarrow handling in multihaul

### DIFF
--- a/docs/multihaul.rst
+++ b/docs/multihaul.rst
@@ -7,9 +7,10 @@ multihaul
 
 This tool allows dwarves to collect several adjacent items at once when
 performing hauling jobs with a wheelbarrow. When enabled, new
-``StoreItemInStockpile`` jobs will automatically attach nearby items so they can
-be hauled in a single trip. By default, up to four additional items within one
-tile of the original item are collected.
+``StoreItemInStockpile`` jobs will automatically attach identical nearby items so
+they can be hauled in a single trip. The script only triggers when a
+wheelbarrow is definitively attached to the job. By default, up to four
+additional items within one tile of the original item are collected.
 
 Usage
 -----


### PR DESCRIPTION
## Summary
- ensure wheelbarrow belongs to the job before expanding hauling
- only grab items identical to the original item
- document strict wheelbarrow requirement and identical item search

## Testing
- `luajit -v` *(fails: command not found)*
- `dfhack-run --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e1b143474832ab6b7448cbc63df51