### PR TITLE
Fix infinite wheelbarrow loops in multihaul

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -36,6 +36,7 @@ Template for new versions:
 - `gui/journal`: fix typo which caused the table of contents to always be regenerated even when not needed
 - `gui/mod-manager`: gracefully handle mods with missing or broken ``info.txt`` files
 - `uniform-unstick`: resolve overlap with new buttons in 51.13
+- `multihaul`: skip wheelbarrows that are not push vehicles and clear stuck jobs
 
 ## Misc Improvements
 

--- a/docs/multihaul.rst
+++ b/docs/multihaul.rst
@@ -11,6 +11,8 @@ performing hauling jobs with a wheelbarrow. When enabled, new
 they can be hauled in a single trip. The script only triggers when a
 wheelbarrow is definitively attached to the job. By default, up to four
 additional items within one tile of the original item are collected.
+Jobs with wheelbarrows that are not assigned as push vehicles are ignored and
+any stuck hauling jobs are automatically cleared.
 
 Usage
 -----


### PR DESCRIPTION
## Summary
- validate that wheelbarrows on hauling jobs are attached as push vehicles
- clear stuck item lists when invalid jobs are detected
- document new behaviour
- note fix in changelog

## Testing
- `luac -p multihaul.lua`

------
https://chatgpt.com/codex/tasks/task_e_687e1e36e1ec832a8c57cbb0610cac96