### PR TITLE
Implement forced wheelbarrow attachment

### DIFF
--- a/docs/multihaul.rst
+++ b/docs/multihaul.rst
@@ -10,6 +10,8 @@ performing hauling jobs with a wheelbarrow. When enabled, new
 ``StoreItemInStockpile`` jobs will automatically attach nearby items so
 they can be hauled in a single trip. Items claimed by another jobs would be ignored.
 Items that are already stored in stockpiles are ignored.
+If the target stockpile has a free assigned wheelbarrow, it is automatically
+attached to the job before additional items are gathered.
 The script only triggers when a wheelbarrow is
 definitively attached to the job. By default, up to ten additional items within
 10 tiles of the original item are collected.


### PR DESCRIPTION
## Summary
- add search for wheelbarrows assigned to the destination stockpile using the stockpile's storage lists
- automatically attach a free wheelbarrow before gathering nearby items
- document automatic wheelbarrow attachment

## Testing
- `pre-commit run --files multihaul.lua docs/multihaul.rst`


------
https://chatgpt.com/codex/tasks/task_e_687ea6abb1ac832abeb30c3b0bdda174