### PR TITLE
Fix multihaul autowheelbarrows

### DIFF
--- a/docs/multihaul.rst
+++ b/docs/multihaul.rst
@@ -45,8 +45,8 @@ Options
     ``sametype`` only matches the item type (like STONE or WOOD), ``samesubtype`` requires type and
     subtype to match, and ``identical`` additionally matches material. The
     default is ``sametype``.
-``--autocancel <on|off|enable|disable>``
-    Auto run finishjobs from time to time.
+``--autowheelbarrows <on|off|enable|disable>``
+    Automatically assign wheelbarrows to jobs that lack them.
 ``--debug <on|off|enable|disable>``
     Show debug messages via ``dfhack.gui.showAnnouncement`` when items are
     attached.

--- a/docs/multihaul.rst
+++ b/docs/multihaul.rst
@@ -7,12 +7,10 @@ multihaul
 
 This tool allows dwarves to collect several adjacent items at once when
 performing hauling jobs with a wheelbarrow. When enabled, new
-``StoreItemInStockpile`` jobs will automatically attach nearby items so
-they can be hauled in a single trip. Items claimed by another jobs would be ignored.
-Items that are already stored in stockpiles are ignored.
-The script only triggers when a wheelbarrow is
-definitively attached to the job. By default, up to ten additional items within
-10 tiles of the original item are collected.
+``StoreItemInStockpile`` jobs with wheelbarrows will automatically attach nearby items so
+they can be hauled in a single trip. Jobs without wheelbarrows would try to attach one if autowheelbarrows option is on.
+Items claimed by another jobs or already stored in stockpiles would be ignored.
+By default, up to ten additional items within 10 tiles of the original item are collected.
 Warning: Destination stockpile filters are currently ignored by the job (because of DF logic). Which items qualify can be controlled
 with the ``--mode`` option.
 Basic usage of wheelbarrows remains the same: dwarfs would use them only if hauling item is heavier than 75
@@ -26,10 +24,8 @@ Usage
     multihaul disable
     multihaul status
     multihaul config [<options>]
-    multihaul finishjobs
 
 The script can also be enabled persistently with ``enable multihaul``.
-finishjobs is an additional command to find and cancel all broken jobs, related to multihaul
 
 Options
 -------

--- a/multihaul.lua
+++ b/multihaul.lua
@@ -69,15 +69,6 @@ local function emptyContainedItems(wheelbarrow)
         end
         dfhack.items.moveToGround(item, wheelbarrow.pos)
     end
-
-    if state.autowheelbarrows then
-        local count = finish_jobs_without_wheelbarrow()
-        if count > 0 and state.debug_enabled then
-            dfhack.gui.showAnnouncement(
-                string.format('multihaul: assigned wheelbarrows to %d job%s', count, count == 1 and '' or 's'),
-                COLOR_CYAN)
-        end
-    end
 end
 
 local function add_nearby_items(job)
@@ -105,19 +96,16 @@ local function add_nearby_items(job)
             return true
         end
     end
-
-    local count = 0
+    
     local abs = math.abs
     for _,it in ipairs(df.global.world.items.other.IN_PLAY) do
         if it ~= target and not it.flags.in_job and it.flags.on_ground and
                 it.pos.z == z and abs(it.pos.x - x) <= state.radius and
-                not it:isWheelbarrow() and
-                --not it._type == df.vehicle_minecartst and
+                not df.item_toolst:is_instance(item) and
                 abs(it.pos.y - y) <= state.radius and
                 not is_stockpiled(it) and
                 matches(it) then
             dfhack.job.attachJobItem(job, it, df.job_role_type.Hauled, -1, -1)
-            count = count + 1
             if state.debug_enabled then
                 dfhack.gui.showAnnouncement(
                     ('multihaul: added %s to hauling job of %s'):format(
@@ -189,21 +177,6 @@ local function clear_job_items(job)
     job.items:resize(0)
 end
 
-local function finish_jobs_without_wheelbarrow()
-    local count = 0
-    for _, job in utils.listpairs(df.global.world.jobs.list) do
-        if job.job_type == df.job_type.StoreItemInStockpile and
-                #job.items > 1 and not find_attached_wheelbarrow(job) then
-            local wheelbarrow = attach_free_wheelbarrow(job)
-            if wheelbarrow then
-                on_new_job(job)
-                count = count + 1
-            end
-        end
-    end
-    return count
-end
-
 local function on_new_job(job)
     if job.job_type ~= df.job_type.StoreItemInStockpile then return end
 
@@ -229,8 +202,7 @@ end
 
 if dfhack.internal.IN_TEST then
     unit_test_hooks = {on_new_job=on_new_job, enable=enable,
-                       load_state=load_state,
-                       finish_jobs_without_wheelbarrow=finish_jobs_without_wheelbarrow}
+                       load_state=load_state}
 end
 
 -- state change handler
@@ -317,9 +289,6 @@ elseif cmd == 'config' then
     persist_state()
     print(('multihaul config: radius=%d max-items=%d mode=%s autowheelbarrows=%s debug=%s')
           :format(state.radius, state.max_items, state.mode, state.autowheelbarrows and 'on' or 'off', state.debug_enabled and 'on' or 'off'))
-elseif cmd == 'finishjobs' then
-    local count = finish_jobs_without_wheelbarrow()
-    print(('finished %d StoreItemInStockpile job%s'):format(count, count == 1 and '' or 's'))
 else
-    qerror('Usage: multihaul [enable|disable|status|config|finishjobs] [--radius N] [--max-items N] [--mode MODE] [--autowheelbarrows on|off] [--debug on|off]')
+    qerror('Usage: multihaul [enable|disable|status|config] [--radius N] [--max-items N] [--mode MODE] [--autowheelbarrows on|off] [--debug on|off]')
 end

--- a/multihaul.lua
+++ b/multihaul.lua
@@ -15,7 +15,7 @@ local function get_default_state()
         radius=10,
         max_items=10,
         mode='sametype',
-		autocancel=true
+        autowheelbarrows=true
     }
 end
 
@@ -69,6 +69,15 @@ local function emptyContainedItems(wheelbarrow)
         end
         dfhack.items.moveToGround(item, wheelbarrow.pos)
     end
+
+    if state.autowheelbarrows then
+        local count = finish_jobs_without_wheelbarrow()
+        if count > 0 and state.debug_enabled then
+            dfhack.gui.showAnnouncement(
+                string.format('multihaul: assigned wheelbarrows to %d job%s', count, count == 1 and '' or 's'),
+                COLOR_CYAN)
+        end
+    end
 end
 
 local function add_nearby_items(job)
@@ -98,12 +107,13 @@ local function add_nearby_items(job)
     end
 
     local count = 0
+    local abs = math.abs
     for _,it in ipairs(df.global.world.items.other.IN_PLAY) do
         if it ~= target and not it.flags.in_job and it.flags.on_ground and
-                it.pos.z == z and math.abs(it.pos.x - x) <= state.radius and
-				not df.item_toolst:is_instance(item) and
-				--not it._type == df.vehicle_minecartst and
-                math.abs(it.pos.y - y) <= state.radius and
+                it.pos.z == z and abs(it.pos.x - x) <= state.radius and
+                not it:isWheelbarrow() and
+                --not it._type == df.vehicle_minecartst and
+                abs(it.pos.y - y) <= state.radius and
                 not is_stockpiled(it) and
                 matches(it) then
             dfhack.job.attachJobItem(job, it, df.job_role_type.Hauled, -1, -1)
@@ -165,9 +175,9 @@ local function attach_free_wheelbarrow(job)
     if not wheelbarrow then return nil end
     if dfhack.job.attachJobItem(job, wheelbarrow,
             df.job_role_type.PushHaulVehicle, -1, -1) then
-		if state.debug_enabled then
-			dfhack.gui.showAnnouncement('multihaul: adding wheelbarrow to a job', COLOR_CYAN)
-		end
+        if state.debug_enabled then
+            dfhack.gui.showAnnouncement('multihaul: adding wheelbarrow to a job', COLOR_CYAN)
+        end
         return wheelbarrow
     end
 end
@@ -181,12 +191,14 @@ end
 
 local function finish_jobs_without_wheelbarrow()
     local count = 0
-	local wheelbarrow
     for _, job in utils.listpairs(df.global.world.jobs.list) do
         if job.job_type == df.job_type.StoreItemInStockpile and
                 #job.items > 1 and not find_attached_wheelbarrow(job) then
-				wheelbarrow = attach_free_wheelbarrow(job)
-				on_new_job(job)
+            local wheelbarrow = attach_free_wheelbarrow(job)
+            if wheelbarrow then
+                on_new_job(job)
+                count = count + 1
+            end
         end
     end
     return count
@@ -196,7 +208,7 @@ local function on_new_job(job)
     if job.job_type ~= df.job_type.StoreItemInStockpile then return end
 
     local wheelbarrow = find_attached_wheelbarrow(job)
-	if not wheelbarrow then
+    if not wheelbarrow then
         wheelbarrow = attach_free_wheelbarrow(job)
     end
     if not wheelbarrow then return end
@@ -260,16 +272,16 @@ local function parse_options(start_idx)
             else
                 state.debug_enabled = true
             end
-        elseif a == '--autocancel' then
+        elseif a == '--autowheelbarrows' then
             local m = args[i + 1]
             if m == 'on' or m == 'enable' then
-                state.autocancel = true
+                state.autowheelbarrows = true
                 i = i + 1
             elseif m == 'off' or m == 'disable' then
-                state.autocancel = false
+                state.autowheelbarrows = false
                 i = i + 1
             else
-                qerror('invalid autocancel option: ' .. tostring(m))
+                qerror('invalid autowheelbarrows option: ' .. tostring(m))
             end
         elseif a == '--radius' then
             i = i + 1
@@ -298,16 +310,16 @@ elseif cmd == 'disable' then
     enable(false)
 elseif cmd == 'status' or not cmd then
     print((state.enabled and 'multihaul is enabled' or 'multihaul is disabled'))
-    print(('radius=%d max-items=%d mode=%s autocancel=%s debug=%s')
-          :format(state.radius, state.max_items, state.mode, state.autocancel and 'on' or 'off', state.debug_enabled and 'on' or 'off'))
+    print(('radius=%d max-items=%d mode=%s autowheelbarrows=%s debug=%s')
+          :format(state.radius, state.max_items, state.mode, state.autowheelbarrows and 'on' or 'off', state.debug_enabled and 'on' or 'off'))
 elseif cmd == 'config' then
     parse_options(2)
     persist_state()
-    print(('multihaul config: radius=%d max-items=%d mode=%s autocancel=%s debug=%s')
-          :format(state.radius, state.max_items, state.mode, state.autocancel and 'on' or 'off', state.debug_enabled and 'on' or 'off'))
+    print(('multihaul config: radius=%d max-items=%d mode=%s autowheelbarrows=%s debug=%s')
+          :format(state.radius, state.max_items, state.mode, state.autowheelbarrows and 'on' or 'off', state.debug_enabled and 'on' or 'off'))
 elseif cmd == 'finishjobs' then
     local count = finish_jobs_without_wheelbarrow()
     print(('finished %d StoreItemInStockpile job%s'):format(count, count == 1 and '' or 's'))
 else
-    qerror('Usage: multihaul [enable|disable|status|config|finishjobs] [--radius N] [--max-items N] [--mode MODE] [--autocancel on|off] [--debug on|off]')
+    qerror('Usage: multihaul [enable|disable|status|config|finishjobs] [--radius N] [--max-items N] [--mode MODE] [--autowheelbarrows on|off] [--debug on|off]')
 end


### PR DESCRIPTION
## Summary
- refine multihaul wheelbarrow automation
- remove buggy item check and optimize searches
- replace `--autocancel` option with `--autowheelbarrows`

## Testing
- `pre-commit run --files multihaul.lua docs/multihaul.rst`

------
https://chatgpt.com/codex/tasks/task_e_6880090b2ae4832abe9bc5f6f3dd955c