### PR TITLE
Add multihaul job cleanup helper

### DIFF
--- a/docs/multihaul.rst
+++ b/docs/multihaul.rst
@@ -24,8 +24,12 @@ Usage
     multihaul disable
     multihaul status
     multihaul config [<options>]
+    multihaul finish
 
 The script can also be enabled persistently with ``enable multihaul``.
+
+``multihaul finish`` cancels any ``StoreItemInStockpile`` jobs that have lost
+their wheelbarrows, freeing attached items.
 
 Options
 -------

--- a/multihaul.lua
+++ b/multihaul.lua
@@ -102,6 +102,7 @@ local function emptyContainedItems(wheelbarrow)
         end
         dfhack.items.moveToGround(item, wheelbarrow.pos)
     end
+    finish_jobs_without_wheelbarrow()
 end
 
 local function add_nearby_items(job)
@@ -189,6 +190,15 @@ local function clear_job_items(job)
         dfhack.gui.showAnnouncement('multihaul: clearing stuck hauling job', COLOR_CYAN)
     end
     job.items:resize(0)
+end
+
+local function finish_jobs_without_wheelbarrow()
+    for _, job in utils.listpairs(df.global.world.jobs.list) do
+        if job.job_type == df.job_type.StoreItemInStockpile and
+                not find_attached_wheelbarrow(job) then
+            dfhack.job.removeJob(job)
+        end
+    end
 end
 
 local function on_new_job(job)
@@ -303,6 +313,8 @@ elseif cmd == 'config' then
     persist_state()
     print(('multihaul config: radius=%d max-items=%d mode=%s autowheelbarrows=%s debug=%s')
           :format(state.radius, state.max_items, state.mode, state.autowheelbarrows and 'on' or 'off', state.debug_enabled and 'on' or 'off'))
+elseif cmd == 'finish' then
+    finish_jobs_without_wheelbarrow()
 else
-    qerror('Usage: multihaul [enable|disable|status|config] [--radius N] [--max-items N] [--mode MODE] [--autowheelbarrows on|off] [--debug on|off]')
+    qerror('Usage: multihaul [enable|disable|status|config|finish] [--radius N] [--max-items N] [--mode MODE] [--autowheelbarrows on|off] [--debug on|off]')
 end


### PR DESCRIPTION
## Summary
- fix stuck hauling jobs by cancelling StoreItemInStockpile jobs missing wheelbarrows
- expose cleanup via `multihaul finish`
- cancel lost wheelbarrow jobs when clearing items from a wheelbarrow

## Testing
- `pre-commit run --files multihaul.lua docs/multihaul.rst`


------
https://chatgpt.com/codex/tasks/task_e_688556fc5ff0832a88671be9b9298977